### PR TITLE
[TASK] Add field for upload theme image

### DIFF
--- a/wp-content/themes/cambodia-ict-camp/functions.php
+++ b/wp-content/themes/cambodia-ict-camp/functions.php
@@ -9,6 +9,16 @@ function camp_theme_enqueue_styles()
     wp_enqueue_style( 'child-style', get_stylesheet_directory_uri() . '/style.css', ['parent-style'] );
 }
 
+// Include custom script
+add_action( 'wp_enqueue_scripts', 'camp_theme_enqueue_scripts' );
+add_action( 'admin_enqueue_scripts', 'camp_theme_enqueue_scripts' );
+
+function camp_theme_enqueue_scripts()
+{
+    wp_enqueue_media();
+    wp_enqueue_script( 'child-custom-script', get_stylesheet_directory_uri() . '/js/custom-script.js', ['jquery'], '1.0', true );
+}
+
 // Add Google Font
 add_action( 'wp_enqueue_scripts', 'add_google_fonts' );
 
@@ -45,3 +55,4 @@ require_once( __DIR__ . '/inc/template-tags.php' );
 
 // Register Custom Form Fields for Taxonomy
 require_once( __DIR__ . '/inc/taxonomy-form-fields/categories/colors.php' );
+require_once( __DIR__ . '/inc/taxonomy-form-fields/categories/images.php' );

--- a/wp-content/themes/cambodia-ict-camp/inc/taxonomy-form-fields/categories/images.php
+++ b/wp-content/themes/cambodia-ict-camp/inc/taxonomy-form-fields/categories/images.php
@@ -1,0 +1,66 @@
+<?php
+add_action( 'category_add_form_fields', 'add_category_image_create_form_field' );
+add_action( 'create_category', 'save_category_image_form_field_data' );
+
+add_action( 'category_edit_form_fields', 'add_category_image_edit_form_field' );
+add_action( 'edited_category', 'save_category_image_form_field_data' );
+
+function add_category_image_create_form_field( $theme )
+{
+    wp_nonce_field( 'save_category_image_form_field_data', 'category_image_form_field_nonce' );
+?>
+    <div class="form-field">
+        <label for="category_image_edit_form_field"><?php _e( 'Theme Image', 'cambodiaictcamp' ); ?></label>
+        <input type="text" name="category_image_edit_form_field" id="category_image_edit_form_field" class="meta-image regular-text" value="<?php echo $theme_image; ?>" readonly>
+        <input type="button" class="button-primary" value="Browse" id="image-upload">
+        <br/>
+        <span class="description"><?php _e( 'Select a image for the theme.', 'cambodiaictcamp' ); ?></span>
+    </div>
+<?php
+}
+
+function add_category_image_edit_form_field( $theme )
+{
+    wp_nonce_field( 'save_category_image_form_field_data', 'category_image_form_field_nonce' );
+
+    $theme_id = $theme->term_id;
+    $theme_image = get_term_meta( $theme_id, '_category_image_value_key', true );
+    ?>
+
+    <tr class="form-field">
+        <th><label for="category_image_edit_form_field"><?php _e( 'Theme Image', 'cambodiaictcamp' ); ?></label></th>
+        <td>
+            <input type="text" name="category_image_edit_form_field" id="category_image_edit_form_field" class="meta-image regular-text" value="<?php echo $theme_image; ?>" style="width: 83%" readonly>
+            <input type="button" class="button-primary" value="Browse" id="image-upload">
+            <br/>
+            <img class="image-preview" src="<?php echo $theme_image; ?>" style="max-width: 250px;">
+            <p class="description"><?php _e( 'Select a color for the theme.', 'cambodiaictcamp' ); ?></p>
+        </td>
+    </tr>
+<?php
+}
+
+function save_category_image_form_field_data( $theme_id )
+{
+    if( ! isset( $_POST['category_image_form_field_nonce'] ) ) {
+        return;
+    }
+
+    if( ! wp_verify_nonce( $_POST['category_image_form_field_nonce'], 'save_category_image_form_field_data' ) ) {
+        return;
+    }
+
+    if( ! current_user_can( 'manage_categories', $theme_id ) ) {
+        return;
+    }
+
+    if( ! isset( $_POST['category_image_edit_form_field'] ) ) {
+        return;
+    }
+
+    $theme_image = $_POST['category_image_edit_form_field'];
+    var_dump($theme_image);
+
+    update_term_meta( $theme_id, '_category_image_value_key', $theme_image );
+}
+?>


### PR DESCRIPTION
Add a field for upload image in Themes Taxonomy (categories).
The image is uploaded through Media Library.

Resource: https://dobsondev.com/2015/01/23/using-the-wordpress-media-uploader/