### PR TITLE
[IMP] Fix counting number of organizer function

### DIFF
--- a/wp-content/themes/cambodia-ict-camp/widgets/camp-organizers.php
+++ b/wp-content/themes/cambodia-ict-camp/widgets/camp-organizers.php
@@ -32,7 +32,7 @@ class Camp_Organizers_Widget extends WP_Widget
 		$organizers = new WP_Query( [ 'post_type' => 'organizers' ] );
 
 		if( $organizers->have_posts() ) {
-			$number = count( $organizers );
+			$number = wp_count_posts( 'organizers' )->publish;
 
 			switch ( $number ) {
 				case 1:


### PR DESCRIPTION
The `count()` function does not work as expected. 
Therefore, it is replaced with `wp_count_posts( $post_type )->publish`.

Resource: https://wordpress.stackexchange.com/questions/26559/counting-the-number-of-posts-custom-post-type-query-problems