### PR TITLE
[IMP] Align element center only when specify

### DIFF
--- a/wp-content/themes/cambodia-ict-camp/inc/shortcode/display-custom-post-type.php
+++ b/wp-content/themes/cambodia-ict-camp/inc/shortcode/display-custom-post-type.php
@@ -58,7 +58,7 @@ function display_custom_post_type( $atts ) {
 
     if ( $custom_posts->have_posts() ) {
 
-        $flex_box_row = ( ! strcmp( $shortcode_atts['flex_box_row'], 'true' ) ) ? 'flex-box-row' : '';
+        $flex_box_row = ( ! strcmp( $shortcode_atts['flex_box_row'], 'true' ) ) ? 'flex-box-row align-items-center' : '';
         $open_new_tab = ( ! strcmp( $shortcode_atts['open_new_tab'], 'true' ) ) ? ' target="_blank"' : '';
         $post_list .= ( ! strcmp( $shortcode_atts['display'], 'list' ) ) ? '<ul>' : ( ! strcmp( $shortcode_atts['row_container'], 'true' ) ) ? '<div class="row ' . $flex_box_row . '">' : '';
 

--- a/wp-content/themes/cambodia-ict-camp/style.css
+++ b/wp-content/themes/cambodia-ict-camp/style.css
@@ -73,6 +73,12 @@ small {
   margin: 0 auto;
 }
 
+.align-items-center {
+  align-items: center;
+
+  -webkit-align-items: center;
+}
+
 #banner-title {
   color: #fff;
 }
@@ -105,14 +111,12 @@ small {
 }
 
 .flex-box-row {
-  align-items: center;
   display: flex;
   flex-direction: row;
   flex-flow: row wrap;
   justify-content: center;
 
   display: -webkit-box;
-  -webkit-align-items: center;
   -webkit-flex-direction: row;
   -webkit-justify-content: center;
 

--- a/wp-content/themes/cambodia-ict-camp/style.css
+++ b/wp-content/themes/cambodia-ict-camp/style.css
@@ -5,7 +5,7 @@
   Author:       Open Development Cambodia
   Author URI: 
   Template:     event-star
-  Version:      1.0.26
+  Version:      1.0.27
   License:
   License URI:
   Tags:         responsive-layout
@@ -75,7 +75,6 @@ small {
 
 .align-items-center {
   align-items: center;
-
   -webkit-align-items: center;
 }
 
@@ -115,11 +114,9 @@ small {
   flex-direction: row;
   flex-flow: row wrap;
   justify-content: center;
-
   display: -webkit-box;
   -webkit-flex-direction: row;
   -webkit-justify-content: center;
-
   display: -moz-box;
   display: -ms-flexbox;
   display: -webkit-flex;

--- a/wp-content/themes/cambodia-ict-camp/widgets/camp-themes.php
+++ b/wp-content/themes/cambodia-ict-camp/widgets/camp-themes.php
@@ -44,7 +44,7 @@ class Camp_Themes_Widget extends WP_Widget
                 }
                 ?>
 
-                <div class="flex-box-row">
+                <div class="flex-box-row align-items-center">
                     <?php
                     foreach( $themes as $theme ) {
                         $theme_image = get_term_meta( $theme->term_id, '_category_image_value_key', true );


### PR DESCRIPTION
Remove `align-items: center` from the default `.flex-box-row` class and add `.align-items-center` to be used where `align-items: center` property is needed.